### PR TITLE
Fix compatibility with RN 0.60.0

### DIFF
--- a/react-native-video.podspec
+++ b/react-native-video.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     s.static_framework = true
   end
 
-  s.dependency "React"
+  s.dependency "React-Core"
 
   s.default_subspec = "Video"
 end


### PR DESCRIPTION
This makes a change to be compatible with RN 0.60.0:

- Depend only on `React-Core` instead of all of React.