### PR TITLE
Maven repo is in node_modules when building as an npm dep

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -41,8 +41,14 @@ repositories {
     mavenLocal()
     google()
     jcenter()
-    maven {
-        url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/"
+    if (project == rootProject) {
+        maven {
+            url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/"
+        }
+    } else {
+        // When building as a dep, the RN's maven repo is locally in the node_modules folder
+        def nodeModulesPath = "${project.buildDir}/../../node_modules/"
+        maven { url "${nodeModulesPath}/react-native/android" }
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,8 +37,14 @@ repositories {
     mavenLocal()
     google()
     jcenter()
-    maven {
-        url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/"
+    if (project == rootProject) {
+        maven {
+            url "https://dl.bintray.com/wordpress-mobile/react-native-mirror/"
+        }
+    } else {
+        // When building as a dep, the RN's maven repo is locally in the node_modules folder
+        def nodeModulesPath = "${project.buildDir}/../../node_modules/"
+        maven { url "${nodeModulesPath}/react-native/android" }
     }
 }
 


### PR DESCRIPTION
When built as a normal npm package, the RN dep should be pulled from the node_modules.

This fixes the cases where a new, incompatible version of RN is otherwise picked up from the maven mirror.