### PR TITLE
Update fork to 5.0.2 take2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## Changelog
 
+### Version 5.0.1
+* Fix crash when RCTVideo's superclass doesn't observe the keyPath 'frame' (iOS) [#1720](https://github.com/react-native-community/react-native-video/pull/1720)
+
 ### Version 5.0.0
 * AndroidX Support
 
 ### Version 4.4.4
 * Handle racing conditions when props are setted on exoplayer
-
 ### Version 4.4.3
 * Fix mute/unmute when controls are present (iOS) [#1654](https://github.com/react-native-community/react-native-video/pull/1654)
 * Fix Android videos being able to play with background music/audio from other apps.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Then follow the instructions for your platform to link react-native-video into y
 
 #### Standard Method
 
+**React Native 0.60 and above**
+
+Run `pod install` in the `ios` directory. Linking is not required in React Native 0.60 and above.
+
+**React Native 0.59 and below**
+
 Run `react-native link react-native-video` to link the react-native-video library.
 
 #### Using CocoaPods (required to enable caching)

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -712,8 +712,6 @@ static int const RCTVideoUnset = -1;
 
         return;
       }
-  } else if ([super respondsToSelector:@selector(observeValueForKeyPath:ofObject:change:context:)]) {
-    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",


### PR DESCRIPTION
Update the fork for Gutenberg Mobile to release version 5.0.2

Related gutenberg-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2205