### PR TITLE
Bump exoplayer to 2.13.3

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -43,7 +43,7 @@ dependencies {
         api "com.facebook.react:react-native:+"
     }
 
-    implementation('com.google.android.exoplayer:exoplayer:2.13.2') {
+    implementation('com.google.android.exoplayer:exoplayer:2.13.3') {
         exclude group: 'com.android.support'
     }
 
@@ -52,7 +52,7 @@ dependencies {
     implementation "androidx.core:core:1.1.0"
     implementation "androidx.media:media:1.1.0"
 
-    implementation('com.google.android.exoplayer:extension-okhttp:2.13.2') {
+    implementation('com.google.android.exoplayer:extension-okhttp:2.13.3') {
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
     }
     implementation 'com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}'


### PR DESCRIPTION
This version is available from the Google repository, so it avoids us needing to host it ourselves since jcenter is shutting down soon and is already pretty unreliable.

These same changes are unreleased in the main react-native-video repository: https://github.com/react-native-video/react-native-video/pull/2552/files

I'm targeting [your PR](https://github.com/WordPress/gutenberg/pull/38426) with this PR so you can easily see these changes in isolation. That means we'll need to merge both of these before we can update and merge [the Gutenberg PR](https://github.com/WordPress/gutenberg/pull/38426)
